### PR TITLE
ECCW-574: Scripts directory not needed or present for docker build.

### DIFF
--- a/Dockerfile-drupal
+++ b/Dockerfile-drupal
@@ -80,8 +80,6 @@ RUN update-rc.d php8.1-fpm disable
 
 COPY --chown=www-data:www-data ./ /drupal
 
-COPY scripts/. /scripts
-
 WORKDIR /drupal
 
 RUN sed -i 's;listen = /run/php/php8.1-fpm.sock;listen = 9000;' /etc/php/8.1/fpm/pool.d/www.conf


### PR DESCRIPTION
A more simplified approach where the file mapping feature in the drupal scaffolding of the composer.json file means that so far the extra composer script file has not been needed.