### PR TITLE
Change non microsite alert banner listing ui path to alert-banners plural.

### DIFF
--- a/config/sync/views.view.localgov_admin_manage_alert_banners.yml
+++ b/config/sync/views.view.localgov_admin_manage_alert_banners.yml
@@ -858,7 +858,7 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: admin/content/alert-banner
+      path: admin/content/alert-banners
       menu:
         type: normal
         title: 'Alert banners'


### PR DESCRIPTION
prevents unwanted alert-banner breadcrumbs which lead to the wrong UI and cause editor confusion.
TICKET: https://eccservicetransformation.atlassian.net/jira/software/projects/LP/boards/25?selectedIssue=LP-164