### PR TITLE
fix(LP-165): Disposal Options exposed form error message for item.

### DIFF
--- a/config/sync/views.view.disposal_options.yml
+++ b/config/sync/views.view.disposal_options.yml
@@ -175,7 +175,7 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: tag
+        type: none
         options: {  }
       empty:
         area:

--- a/web/modules/custom/ecc_waste/ecc_waste.module
+++ b/web/modules/custom/ecc_waste/ecc_waste.module
@@ -97,6 +97,36 @@ function ecc_waste_form_node_waste_disposal_option_edit_form_alter(&$form, \Drup
   $form['field_disposal_option_items']['widget']['#weight'] = 1;
 }
 
+/**
+ * Implements hook_form_alter().
+ */
+function ecc_waste_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if ($form['#id'] === 'views-exposed-form-disposal-options-page-disposal-search') {
+    $form['#validate'][] = '_ecc_waste_form_views_exposed_form_validate';
+    //$form['#cache']['contexts'][] = 'url.query_args:item';
+  }
+}
+
+/**
+ * Validate the Disposal Options view exposed form.
+ *
+ * @param array $form
+ *   Form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Form state.
+ *
+ * @return void
+ */
+function _ecc_waste_form_views_exposed_form_validate(&$form, FormStateInterface $form_state): void {
+  if (\Drupal::routeMatch()->getRouteName() !== 'views_filters.autocomplete') {
+    $item_text = $form_state->getValue('item');
+    $taxonomy_storage = \Drupal::entityTypeManager()
+      ->getStorage('taxonomy_term');
+    if (!$taxonomy_storage->loadByProperties(['name' => $item_text])) {
+      $form_state->setErrorByName('item', t('Item not recognised, please start typing an item and then select from the drop down list'));
+    }
+  }
+}
 
 /**
  * Implements hook_views_data_alter().

--- a/web/modules/custom/ecc_waste/ecc_waste.module
+++ b/web/modules/custom/ecc_waste/ecc_waste.module
@@ -122,7 +122,7 @@ function _ecc_waste_form_views_exposed_form_validate(&$form, FormStateInterface 
     $taxonomy_storage = \Drupal::entityTypeManager()
       ->getStorage('taxonomy_term');
     if (!$taxonomy_storage->loadByProperties(['name' => $item_text])) {
-      $form_state->setErrorByName('item', t('Item not recognised, please start typing an item and then select from the drop down list'));
+      $form_state->setErrorByName('item', t('Item not recognised, please start typing an item and then select from the drop down list.'));
     }
   }
 }

--- a/web/modules/custom/ecc_waste/ecc_waste.module
+++ b/web/modules/custom/ecc_waste/ecc_waste.module
@@ -98,7 +98,7 @@ function ecc_waste_form_node_waste_disposal_option_edit_form_alter(&$form, \Drup
 }
 
 /**
- * Implements hook_form_alter().
+ * Implements hook_form_FORM_ID_alter().
  */
 function ecc_waste_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if ($form['#id'] === 'views-exposed-form-disposal-options-page-disposal-search') {

--- a/web/modules/custom/ecc_waste/ecc_waste.module
+++ b/web/modules/custom/ecc_waste/ecc_waste.module
@@ -103,7 +103,6 @@ function ecc_waste_form_node_waste_disposal_option_edit_form_alter(&$form, \Drup
 function ecc_waste_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if ($form['#id'] === 'views-exposed-form-disposal-options-page-disposal-search') {
     $form['#validate'][] = '_ecc_waste_form_views_exposed_form_validate';
-    //$form['#cache']['contexts'][] = 'url.query_args:item';
   }
 }
 


### PR DESCRIPTION
Display error message if item does not match a Waste Item taxonomy term name.
Remove caching from Disposal Options view - otherwise the error is not displayed when the same invalid item is submitted again.