### PR TITLE
Fix replicate functionality for node entities.

### DIFF
--- a/config/sync/replicate_ui.settings.yml
+++ b/config/sync/replicate_ui.settings.yml
@@ -1,4 +1,5 @@
 _core:
   default_config_hash: kTj4VrfBBlmTowM6GEcqnV6rS5DvkIeeWJSGHyda1e4
-entity_types: {  }
+entity_types:
+  - node
 check_edit_access: false

--- a/web/modules/custom/localgov_microsites_group_content_clone/localgov_microsites_group_content_clone.module
+++ b/web/modules/custom/localgov_microsites_group_content_clone/localgov_microsites_group_content_clone.module
@@ -42,13 +42,20 @@ function localgov_microsites_group_content_clone_form_submit(array &$form, FormS
   $node->save();
 
   // Add this replicated node to the current microsite.
+  /** @var \Drupal\domain\DomainInterface $current_domain */
   $current_domain = \Drupal::service('domain.negotiator')->getActiveDomain();
-  if ($current_domain && !empty($current_domain->get('third_party_settings'))) {
-    $current_group_id = $current_domain->get('third_party_settings')['domain_group']['group'];
-    $current_group = \Drupal::entityTypeManager()->getStorage('group')->load($current_group_id);
+  if (!empty($current_domain)) {
+    $group_uuid = $current_domain->getThirdPartySetting('group_context_domain', 'group_uuid');
+    if (!empty($group_uuid)) {
+      /** @var \Drupal\group\Entity\GroupInterface $group */
+      $group = \Drupal::service('entity.repository')
+        ->loadEntityByUuid('group', $group_uuid);
 
-    // Add relationship between the current group and the node that was cloned.
-    $current_group->addRelationship($node, 'group_node:' . $node->getType());
-    $current_group->save();
+      // Add relationship between the current group and the cloned node.
+      if (!empty($group)) {
+        $group->addRelationship($node, 'group_node:' . $node->getType());
+        $group->save();
+      }
+    }
   }
 }


### PR DESCRIPTION
https://eccservicetransformation.atlassian.net/browse/LP-201

Before this change, user entities could not be edited and you would get a fatal error. We had to effectively turn Replicate off.
After this change, Replicate works, and users are editable.

Contrib function "localgov_microsites_group_update_9004" migrated domain record third party settings from "domain_group" to "group_context_domain", but custom module function "localgov_microsites_group_content_clone_form_submit" kept using the original values.

This change sorts out the custom module.