### PR TITLE
202410 404blocks lp 225

### DIFF
--- a/web/themes/custom/love_essex/css/components/footer.css
+++ b/web/themes/custom/love_essex/css/components/footer.css
@@ -1,6 +1,7 @@
 .lgd-region--pre-footer {
   padding-top: var(--vertical-rhythm-spacing);
   background-color: var(--color-accent);
+  border: 1px solid var(--color-accent);
   * {
     color: var(--color-white);
   }

--- a/web/themes/custom/love_essex/templates/layout/status-pages/page--403.html.twig
+++ b/web/themes/custom/love_essex/templates/layout/status-pages/page--403.html.twig
@@ -1,6 +1,21 @@
 {% extends "@localgov_base/layout/status-pages/page-status.html.twig" %}
 
 {% block header %}
+    {{ attach_library('localgov_microsites_base/header') }}
+    {{ attach_library('localgov_microsites_base/header-js') }}
+    {{ attach_library('love_essex/alerts') }}
+    {{ attach_library('localgov_microsites_base/footer') }}
+    {% if is_front %}
+      {{ attach_library('love_essex/front') }}
+    {% endif %}
+
+    <div class="off-canvas" id="off-canvas" data-expanded="false">
+      {{ page.off_canvas }}
+    </div>
+
+    {% if has_header %}
+      {{ page.header }}
+    {% endif %}
     <header class="microsite-header">
         {% include "@localgov_microsites_base/layout/includes/microsites-header.html.twig" %}
     </header>

--- a/web/themes/custom/love_essex/templates/layout/status-pages/page--403.html.twig
+++ b/web/themes/custom/love_essex/templates/layout/status-pages/page--403.html.twig
@@ -5,3 +5,18 @@
         {% include "@localgov_microsites_base/layout/includes/microsites-header.html.twig" %}
     </header>
 {% endblock %}
+
+{% block pre_footer %}
+  {% if page.pre_footer %}
+    {{ page.pre_footer }}
+  {% endif %}
+{% endblock %}
+
+{% block footer %}
+  <footer class="microsite-footer">
+    {% include "@love_essex/layout/includes/microsites-footer.html.twig" %}
+    {% if has_footer %}
+      {{ page.footer }}
+    {% endif %}
+  </footer>
+{% endblock %}

--- a/web/themes/custom/love_essex/templates/layout/status-pages/page--404.html.twig
+++ b/web/themes/custom/love_essex/templates/layout/status-pages/page--404.html.twig
@@ -1,6 +1,25 @@
+
+
+
+
 {% extends "@localgov_base/layout/status-pages/page-status.html.twig" %}
 
 {% block header %}
+    {{ attach_library('localgov_microsites_base/header') }}
+    {{ attach_library('localgov_microsites_base/header-js') }}
+    {{ attach_library('love_essex/alerts') }}
+    {{ attach_library('localgov_microsites_base/footer') }}
+    {% if is_front %}
+      {{ attach_library('love_essex/front') }}
+    {% endif %}
+
+    <div class="off-canvas" id="off-canvas" data-expanded="false">
+      {{ page.off_canvas }}
+    </div>
+
+    {% if has_header %}
+      {{ page.header }}
+    {% endif %}
     <header class="microsite-header">
         {% include "@localgov_microsites_base/layout/includes/microsites-header.html.twig" %}
     </header>

--- a/web/themes/custom/love_essex/templates/layout/status-pages/page--404.html.twig
+++ b/web/themes/custom/love_essex/templates/layout/status-pages/page--404.html.twig
@@ -5,3 +5,18 @@
         {% include "@localgov_microsites_base/layout/includes/microsites-header.html.twig" %}
     </header>
 {% endblock %}
+
+{% block pre_footer %}
+  {% if page.pre_footer %}
+    {{ page.pre_footer }}
+  {% endif %}
+{% endblock %}
+
+{% block footer %}
+  <footer class="microsite-footer">
+    {% include "@love_essex/layout/includes/microsites-footer.html.twig" %}
+    {% if has_footer %}
+      {{ page.footer }}
+    {% endif %}
+  </footer>
+{% endblock %}


### PR DESCRIPTION
Add twig blocks for footer regions to 403 and 404 templates in love essex theme. 
Also include regions and libraries to make the mobile menu work.
Add green border to love essex prefooter to match background and for infill of background colour.
https://eccservicetransformation.atlassian.net/browse/LP-225