### PR TITLE
Wrap wysiwyg editor toolbar to stop it bleeding into uselessness.

### DIFF
--- a/config/sync/editor.editor.wysiwyg.yml
+++ b/config/sync/editor.editor.wysiwyg.yml
@@ -23,7 +23,7 @@ settings:
       - '|'
       - undo
       - redo
-      - '|'
+      - '-'
       - link
       - '|'
       - bulletedList


### PR DESCRIPTION
https://eccservicetransformation.atlassian.net/browse/LP-307

adds config to wrap toolbar to stop it from being obscured