### PR TITLE
Do not display the block label for the waste search component.

### DIFF
--- a/web/modules/custom/ecc_waste/templates/paragraph--waste-search.html.twig
+++ b/web/modules/custom/ecc_waste/templates/paragraph--waste-search.html.twig
@@ -13,7 +13,7 @@
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
     {% block content %}
-      {{ drupal_block('views_exposed_filter_block:disposal_options-page_disposal_search') }}
+      {{ drupal_block('views_exposed_filter_block:disposal_options-page_disposal_search', {label_display: false}) }}
     {% endblock %}
   </div>
 {% endblock paragraph %}


### PR DESCRIPTION
https://eccservicetransformation.atlassian.net/browse/LP-319
Change to custom paragraph twig template to 
inject a setting in `drupal_block()`
to prevent the block label from displaying